### PR TITLE
Add basket ref and multi-basket support

### DIFF
--- a/example/shop/migrations/0003_basket_ref_field.py
+++ b/example/shop/migrations/0003_basket_ref_field.py
@@ -1,0 +1,17 @@
+from uuid import uuid4
+from django.db import migrations, models
+from django.utils.translation import gettext_lazy as _
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("shop", "0002_rename_owner_field"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="basket",
+            name="ref",
+            field=models.CharField(max_length=128, unique=True, default=uuid4, verbose_name=_("Reference")),
+        ),
+    ]

--- a/example/shop/models/basket.py
+++ b/example/shop/models/basket.py
@@ -1,9 +1,13 @@
 # models.py
+from uuid import uuid4
+
+from django.db import models
+
 from salesman.basket.models import BaseBasket, BaseBasketItem
 
 
 class Basket(BaseBasket):
-    pass
+    ref = models.CharField(max_length=128, unique=True, default=uuid4)
 
 
 class BasketItem(BaseBasketItem):

--- a/example/tests/basket/test_basket_models.py
+++ b/example/tests/basket/test_basket_models.py
@@ -40,6 +40,15 @@ def test_get_or_create_basket_from_request(rf, django_user_model):
     basket, _ = Basket.objects.get_or_create_from_request(request)
     assert request.user.basket_set.count() == 1
 
+    # staff user with ref should bypass merge and create new basket
+    request.GET = request.GET.copy()
+    request.GET["ref"] = "pos1"
+    request.user.is_staff = True
+    basket_pos, created = Basket.objects.get_or_create_from_request(request)
+    assert created
+    assert basket_pos.ref == "pos1"
+    assert Basket.objects.count() == 2
+
 
 @pytest.mark.django_db
 def test_basket_str():

--- a/example/tests/basket/test_basket_views.py
+++ b/example/tests/basket/test_basket_views.py
@@ -11,7 +11,7 @@ BasketItem = get_salesman_model("BasketItem")
 
 
 @pytest.mark.django_db
-def test_basket_views():
+def test_basket_views(django_user_model):
     url = reverse("salesman-basket-list")
     client = APIClient()
 
@@ -109,3 +109,17 @@ def test_basket_views():
     assert response.status_code == 204
     response = client.get(url)
     assert response.json()["id"] == basket_id + 1
+
+    # staff multi-basket via ref
+    staff = django_user_model.objects.create_user(
+        username="staff", password="pw", is_staff=True
+    )
+    client.force_authenticate(staff)
+    response = client.get(url + "?ref=pos-1")
+    assert response.status_code == 200
+    assert response.json()["ref"] == "pos-1"
+    response = client.get(url + "?ref=pos-2")
+    assert response.status_code == 200
+    assert response.json()["ref"] == "pos-2"
+    Basket = get_salesman_model("Basket")
+    assert Basket.objects.filter(user=staff).count() == 2

--- a/salesman/basket/models.py
+++ b/salesman/basket/models.py
@@ -26,16 +26,36 @@ class BasketManager(models.Manager["BaseBasket"]):
     def get_or_create_from_request(
         self,
         request: HttpRequest,
+        ref: str | None = None,
     ) -> tuple[BaseBasket, bool]:
         """
         Get basket from request or create a new one.
-        If user is logged in session basket gets merged into a user basket.
+        If ``ref`` is supplied or detected on the request the merging logic is
+        skipped and basket with given reference (and optionally user) is fetched
+        or created. Otherwise if user is logged in session basket gets merged
+        into a user basket.
 
         Returns:
             tuple: (basket, created)
         """
         if not hasattr(request, "session"):
             request.session = {}
+
+        if ref is None:
+            ref = (
+                getattr(getattr(request, "GET", {}), "get", lambda x: None)("ref")
+                or getattr(request, "headers", {}).get("X-Basket-Ref")
+                or getattr(getattr(request, "data", {}), "get", lambda x: None)("ref")
+                or getattr(getattr(request, "POST", {}), "get", lambda x: None)("ref")
+            )
+
+        if ref:
+            kwargs = {"ref": ref}
+            if getattr(request, "user", None) and request.user.is_authenticated:
+                kwargs["user_id"] = request.user.id
+            basket, created = self.get_or_create(**kwargs)
+            return basket, created
+
         try:
             session_basket_id = request.session[BASKET_ID_SESSION_KEY]
             session_basket = self.get(id=session_basket_id, user=None)

--- a/salesman/basket/serializers.py
+++ b/salesman/basket/serializers.py
@@ -185,7 +185,15 @@ class BasketSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Basket
-        fields = ["id", "items", "subtotal", "extra_rows", "total", "extra"]
+        fields = [
+            "id",
+            "ref",
+            "items",
+            "subtotal",
+            "extra_rows",
+            "total",
+            "extra",
+        ]
 
     def to_representation(self, basket: BaseBasket) -> Any:
         basket.update(self.context["request"])

--- a/salesman/basket/views.py
+++ b/salesman/basket/views.py
@@ -47,8 +47,13 @@ class BasketViewSet(viewsets.ModelViewSet):
     def get_basket(self) -> BaseBasket:
         if self._basket:
             return self._basket
+        ref = (
+            self.request.query_params.get("ref")
+            or self.request.headers.get("X-Basket-Ref")
+            or getattr(self.request.data, "get", lambda x: None)("ref")
+        )
         basket: BaseBasket
-        basket, _ = Basket.objects.get_or_create_from_request(self.request)
+        basket, _ = Basket.objects.get_or_create_from_request(self.request, ref=ref)
         self._basket = basket
         return basket
 


### PR DESCRIPTION
## Summary
- create swappable `Basket` and `BasketItem` models in example project
- add unique `ref` to Basket model and expose via serializer
- support reference aware retrieval in `BasketManager` and `BasketViewSet`
- update example tests for new behaviour

## Testing
- `pre-commit run --files example/shop/models/basket.py example/shop/migrations/0003_basket_ref_field.py salesman/basket/models.py salesman/basket/serializers.py salesman/basket/views.py example/tests/basket/test_basket_models.py example/tests/basket/test_basket_views.py` *(fails: command not found)*
- `pytest -q -o addopts=''` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68409d60e08483259f7014580344d5ab